### PR TITLE
Pretraining Data Preparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ It streams a HuggingFace dataset, samples raw text with unit-based limits, and w
 welt-prepare-data \
     --dataset_name HuggingFaceFW/fineweb \
     --dataset_config sample-10BT \
-    --max_total_units 3200000000 \
+    --train_split_units 3200000000 \
     --num_units_per_file 100000000 \
     --max_seq_length 512 \
     --seed 42 \
@@ -117,7 +117,7 @@ Multiple datasets can be prepared into the same output directory:
 ```shell
 welt-prepare-data \
     --dataset_name monology/pile-uncopyrighted \
-    --max_total_units 1000000000 \
+    --train_split_units 1000000000 \
     --num_units_per_file 100000000 \
     --max_seq_length 512 \
     --output_path /scratch/data/pretrain
@@ -149,7 +149,8 @@ welt-train config.yaml --prepared_data_path /scratch/data/pretrain
 | `--text_template` | Python format string template (optional) |
 | `--language` | Language tag to store with each example (e.g., "eng_Latn") |
 | `--unit_type` | Unit type for counting: "words" or "chars" (default: "words") |
-| `--max_total_units` | Max total units to sample (optional) |
+| `--train_split_units` | Number of units for the train split (optional) |
+| `--validation_split_units` | Number of units for the validation split (optional; requires `--train_split_units`) |
 | `--num_units_per_file` | Max units per shard file (optional) |
 | `--max_seq_length` | Max words per example; splits long documents using word segmentation |
 | `--max_bytes_per_word` | Max UTF-8 bytes per word; should match training config `max_word_length - 2` (default: 126) |

--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ welt-train config.yaml --prepared_data_path /scratch/data/pretrain
 | `--text_template` | Python format string template (optional) |
 | `--language` | Language tag to store with each example (e.g., "eng_Latn") |
 | `--unit_type` | Unit type for counting: "words" or "chars" (default: "words") |
-| `--train_split_units` | Number of units for the train split (required) |
-| `--validation_split_units` | Number of units for the validation split (required) |
+| `--train_split_units` | Number of units for the train split (default: 0, no train shards) |
+| `--validation_split_units` | Number of units for the validation split (default: 0, no validation shards) |
 | `--num_units_per_file` | Max units per shard file (optional) |
 | `--max_seq_length` | Max words per example; splits long documents using word segmentation |
 | `--max_bytes_per_word` | Max UTF-8 bytes per word; should match training config `max_word_length - 2` (default: 126) |

--- a/README.md
+++ b/README.md
@@ -134,10 +134,10 @@ The output directory contains sharded `.jsonl.gz` files and a `{prefix}-metadata
 └── pile-uncopyrighted-metadata.json
 ```
 
-Then train using the preprocessed data:
+Then train using the prepared data:
 
 ```shell
-welt-train config.yaml --preprocessed_data_path /scratch/data/pretrain
+welt-train config.yaml --prepared_data_path /scratch/data/pretrain
 ```
 
 | Argument | Description |
@@ -152,6 +152,7 @@ welt-train config.yaml --preprocessed_data_path /scratch/data/pretrain
 | `--max_total_units` | Max total units to sample (optional) |
 | `--num_units_per_file` | Max units per shard file (optional) |
 | `--max_seq_length` | Max words per example; splits long documents using word segmentation |
+| `--max_bytes_per_word` | Max UTF-8 bytes per word; should match training config `max_word_length - 2` (default: 126) |
 | `--seed` | Random seed for shuffling |
 | `--drop_remainder` | Drop partial chunks at document boundaries |
 | `--output_path` | Output directory path (required) |

--- a/README.md
+++ b/README.md
@@ -123,14 +123,15 @@ welt-prepare-data \
     --output_path /scratch/data/pretrain
 ```
 
-The output directory contains sharded `.jsonl.gz` files and a `metadata.json` per run:
+The output directory contains sharded `.jsonl.gz` files and a `{prefix}-metadata.json` per dataset:
 
 ```
 /scratch/data/pretrain/
-├── fineweb-sample-10BT-00000.jsonl.gz
-├── fineweb-sample-10BT-00001.jsonl.gz
-├── pile-uncopyrighted-00000.jsonl.gz
-└── metadata.json
+├── fineweb-sample-10BT-00000000.jsonl.gz
+├── fineweb-sample-10BT-00000001.jsonl.gz
+├── fineweb-sample-10BT-metadata.json
+├── pile-uncopyrighted-00000000.jsonl.gz
+└── pile-uncopyrighted-metadata.json
 ```
 
 Then train using the preprocessed data:
@@ -151,7 +152,6 @@ welt-train config.yaml --preprocessed_data_path /scratch/data/pretrain
 | `--max_total_units` | Max total units to sample (optional) |
 | `--num_units_per_file` | Max units per shard file (optional) |
 | `--max_seq_length` | Max words per example; splits long documents using word segmentation |
-| `--max_bytes_per_word` | Max bytes per word for word segmentation (default: 126) |
 | `--seed` | Random seed for shuffling |
 | `--drop_remainder` | Drop partial chunks at document boundaries |
 | `--output_path` | Output directory path (required) |

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ welt-prepare-data \
     --dataset_name HuggingFaceFW/fineweb \
     --dataset_config sample-10BT \
     --train_split_units 3200000000 \
+    --validation_split_units 100000000 \
     --num_units_per_file 100000000 \
     --max_seq_length 512 \
     --seed 42 \
@@ -118,6 +119,7 @@ Multiple datasets can be prepared into the same output directory:
 welt-prepare-data \
     --dataset_name monology/pile-uncopyrighted \
     --train_split_units 1000000000 \
+    --validation_split_units 50000000 \
     --num_units_per_file 100000000 \
     --max_seq_length 512 \
     --output_path /scratch/data/pretrain
@@ -149,8 +151,8 @@ welt-train config.yaml --prepared_data_path /scratch/data/pretrain
 | `--text_template` | Python format string template (optional) |
 | `--language` | Language tag to store with each example (e.g., "eng_Latn") |
 | `--unit_type` | Unit type for counting: "words" or "chars" (default: "words") |
-| `--train_split_units` | Number of units for the train split (optional) |
-| `--validation_split_units` | Number of units for the validation split (optional; requires `--train_split_units`) |
+| `--train_split_units` | Number of units for the train split (required) |
+| `--validation_split_units` | Number of units for the validation split (required) |
 | `--num_units_per_file` | Max units per shard file (optional) |
 | `--max_seq_length` | Max words per example; splits long documents using word segmentation |
 | `--max_bytes_per_word` | Max UTF-8 bytes per word; should match training config `max_word_length - 2` (default: 126) |

--- a/README.md
+++ b/README.md
@@ -160,6 +160,16 @@ welt-train config.yaml --prepared_data_path /scratch/data/pretrain
 | `--drop_remainder` | Drop partial chunks at document boundaries |
 | `--output_path` | Output directory path (required) |
 
+### Verifying Prepared Data
+
+After preparing data, verify integrity with `welt-verify-data`:
+
+```shell
+welt-verify-data --data_path /scratch/data/pretrain
+```
+
+This checks that shard counts and example counts match the metadata, and warns if train/validation splits from the same source were created separately (risking data contamination).
+
 ## Training
 
 Training instructions are available in the [welt_training/README.md](./welt_training/README.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,3 +81,4 @@ testpaths = [
 [project.scripts]
 welt-train = "welt_training.train:train"
 welt-prepare-data = "welt_training.prepare_data:main"
+welt-verify-data = "welt_training.verify_data:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,3 +80,4 @@ testpaths = [
 
 [project.scripts]
 welt-train = "welt_training.train:train"
+welt-prepare-data = "welt_training.prepare_data:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ train = [
     "scikit-learn", # For "accuracy" metric in evaluate
     "sacrebleu", # For usual bleu/chrF metrics
     "wandb", # For experiment tracking
+    "zstandard", # For compressing the data
 ]
 
 dion = [

--- a/tests/test_prepare_data.py
+++ b/tests/test_prepare_data.py
@@ -9,7 +9,6 @@ from datasets import load_dataset
 
 from welt_training.prepare_data import get_shard_prefix, main
 
-
 # --- get_shard_prefix ---
 
 

--- a/tests/test_prepare_data.py
+++ b/tests/test_prepare_data.py
@@ -56,7 +56,8 @@ def test_prepare_data_creates_shards(temp_output_dir, monkeypatch):
     assert len(shard_files) >= 2, f"Expected at least 2 shards, got {len(shard_files)}"
 
     # Verify metadata
-    with open(f"{temp_output_dir}/metadata.json") as f:
+    prefix = get_shard_prefix("wikitext", "wikitext-2-raw-v1")
+    with open(f"{temp_output_dir}/{prefix}-metadata.json") as f:
         metadata = json.load(f)
     assert metadata["format"] == "welt-preprocessed-v1"
     assert metadata["total_units"] <= 500
@@ -103,7 +104,8 @@ def test_prepare_data_with_language(temp_output_dir, monkeypatch):
                 example = json.loads(line)
                 assert example["language"] == "eng_Latn"
 
-    with open(f"{temp_output_dir}/metadata.json") as f:
+    prefix = get_shard_prefix("wikitext", "wikitext-2-raw-v1")
+    with open(f"{temp_output_dir}/{prefix}-metadata.json") as f:
         metadata = json.load(f)
     assert metadata["language"] == "eng_Latn"
 
@@ -124,7 +126,8 @@ def test_prepare_data_unit_type_chars(temp_output_dir, monkeypatch):
     )
     main()
 
-    with open(f"{temp_output_dir}/metadata.json") as f:
+    prefix = get_shard_prefix("wikitext", "wikitext-2-raw-v1")
+    with open(f"{temp_output_dir}/{prefix}-metadata.json") as f:
         metadata = json.load(f)
     assert metadata["unit_type"] == "chars"
     assert metadata["total_units"] <= 500
@@ -146,7 +149,8 @@ def test_prepare_data_with_max_seq_length(temp_output_dir, monkeypatch):
     )
     main()
 
-    with open(f"{temp_output_dir}/metadata.json") as f:
+    prefix = get_shard_prefix("wikitext", "wikitext-2-raw-v1")
+    with open(f"{temp_output_dir}/{prefix}-metadata.json") as f:
         metadata = json.load(f)
     assert metadata["max_seq_length"] == 32
     assert metadata["total_units"] <= 500

--- a/tests/test_prepare_data.py
+++ b/tests/test_prepare_data.py
@@ -43,7 +43,8 @@ def test_prepare_data_creates_shards(temp_output_dir, monkeypatch):
             "welt-prepare-data",
             "--dataset_name", "wikitext",
             "--dataset_config", "wikitext-2-raw-v1",
-            "--train_split_units", "500",
+            "--train_split_units", "400",
+            "--validation_split_units", "100",
             "--num_units_per_file", "200",
             "--seed", "42",
             "--output_path", temp_output_dir,
@@ -89,7 +90,8 @@ def test_prepare_data_with_language(temp_output_dir, monkeypatch):
             "welt-prepare-data",
             "--dataset_name", "wikitext",
             "--dataset_config", "wikitext-2-raw-v1",
-            "--train_split_units", "200",
+            "--train_split_units", "160",
+            "--validation_split_units", "40",
             "--language", "eng_Latn",
             "--seed", "42",
             "--output_path", temp_output_dir,
@@ -118,7 +120,8 @@ def test_prepare_data_unit_type_chars(temp_output_dir, monkeypatch):
             "welt-prepare-data",
             "--dataset_name", "wikitext",
             "--dataset_config", "wikitext-2-raw-v1",
-            "--train_split_units", "500",
+            "--train_split_units", "400",
+            "--validation_split_units", "100",
             "--unit_type", "chars",
             "--seed", "42",
             "--output_path", temp_output_dir,
@@ -141,7 +144,8 @@ def test_prepare_data_with_max_seq_length(temp_output_dir, monkeypatch):
             "welt-prepare-data",
             "--dataset_name", "wikitext",
             "--dataset_config", "wikitext-2-raw-v1",
-            "--train_split_units", "500",
+            "--train_split_units", "400",
+            "--validation_split_units", "100",
             "--max_seq_length", "32",
             "--seed", "42",
             "--output_path", temp_output_dir,
@@ -265,21 +269,7 @@ def test_load_prepared_data_split_aware(temp_output_dir, monkeypatch):
     assert len(result["train"]) + len(result["validation"]) == metadata["num_examples"]
 
 
-def test_load_prepared_data_requires_validation_shards(temp_output_dir, monkeypatch):
+def test_load_prepared_data_requires_validation_shards(temp_output_dir):
     """Test that load_prepared_data raises when validation shards are missing."""
-    monkeypatch.setattr(
-        "sys.argv",
-        [
-            "welt-prepare-data",
-            "--dataset_name", "wikitext",
-            "--dataset_config", "wikitext-2-raw-v1",
-            "--train_split_units", "500",
-            "--seed", "42",
-            "--output_path", temp_output_dir,
-        ],
-    )
-    main()
-
-    # Without --validation_split_units, shards have no split marker → error
-    with pytest.raises(ValueError, match="validation"):
+    with pytest.raises(ValueError, match="train"):
         load_prepared_data(temp_output_dir)

--- a/tests/test_prepare_data.py
+++ b/tests/test_prepare_data.py
@@ -157,7 +157,7 @@ def test_prepare_data_with_max_seq_length(temp_output_dir, monkeypatch):
 
     # Verify each example has at most max_seq_length words
     from words_segmentation.tokenizer import WordsSegmentationTokenizer
-    pretokenizer = WordsSegmentationTokenizer()
+    pretokenizer = WordsSegmentationTokenizer(max_bytes=126)
 
     shard_files = sorted(glob.glob(f"{temp_output_dir}/*.jsonl.gz"))
     for path in shard_files:

--- a/tests/test_prepare_data.py
+++ b/tests/test_prepare_data.py
@@ -1,0 +1,164 @@
+import glob
+import gzip
+import json
+import shutil
+import tempfile
+
+import pytest
+from datasets import load_dataset
+
+from welt_training.prepare_data import get_shard_prefix, main
+
+
+# --- get_shard_prefix ---
+
+
+def test_get_shard_prefix_with_org():
+    assert get_shard_prefix("HuggingFaceFW/fineweb", None) == "fineweb"
+
+
+def test_get_shard_prefix_with_config():
+    assert get_shard_prefix("HuggingFaceFW/fineweb", "sample-10BT") == "fineweb-sample-10BT"
+
+
+def test_get_shard_prefix_no_org():
+    assert get_shard_prefix("wikitext", "wikitext-2-raw-v1") == "wikitext-wikitext-2-raw-v1"
+
+
+# --- Integration tests ---
+
+
+@pytest.fixture
+def temp_output_dir():
+    temp_dir = tempfile.mkdtemp(prefix="test_prepare_data_")
+    yield temp_dir
+    shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def test_prepare_data_creates_shards(temp_output_dir, monkeypatch):
+    """Test that welt-prepare-data creates sharded .jsonl.gz files that can be loaded."""
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "welt-prepare-data",
+            "--dataset_name", "wikitext",
+            "--dataset_config", "wikitext-2-raw-v1",
+            "--max_total_units", "500",
+            "--num_units_per_file", "200",
+            "--seed", "42",
+            "--output_path", temp_output_dir,
+        ],
+    )
+    main()
+
+    # Verify shards were created
+    shard_files = sorted(glob.glob(f"{temp_output_dir}/*.jsonl.gz"))
+    assert len(shard_files) >= 2, f"Expected at least 2 shards, got {len(shard_files)}"
+
+    # Verify metadata
+    with open(f"{temp_output_dir}/metadata.json") as f:
+        metadata = json.load(f)
+    assert metadata["format"] == "welt-preprocessed-v1"
+    assert metadata["total_units"] <= 500
+    assert metadata["unit_type"] == "words"
+    assert metadata["num_shards"] == len(shard_files)
+
+    # Verify each shard is valid gzipped JSONL with a "text" field
+    total_examples = 0
+    for path in shard_files:
+        with gzip.open(path, "rt") as f:
+            for line in f:
+                example = json.loads(line)
+                assert "text" in example
+                assert isinstance(example["text"], str)
+                total_examples += 1
+    assert total_examples == metadata["num_examples"]
+
+    # Verify loading with HuggingFace datasets (same path as train.py)
+    ds = load_dataset("json", data_files=shard_files, split="train")
+    assert len(ds) == total_examples
+    assert "text" in ds.features
+
+
+def test_prepare_data_with_language(temp_output_dir, monkeypatch):
+    """Test that --language stores language metadata in each example."""
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "welt-prepare-data",
+            "--dataset_name", "wikitext",
+            "--dataset_config", "wikitext-2-raw-v1",
+            "--max_total_units", "200",
+            "--language", "eng_Latn",
+            "--seed", "42",
+            "--output_path", temp_output_dir,
+        ],
+    )
+    main()
+
+    shard_files = sorted(glob.glob(f"{temp_output_dir}/*.jsonl.gz"))
+    for path in shard_files:
+        with gzip.open(path, "rt") as f:
+            for line in f:
+                example = json.loads(line)
+                assert example["language"] == "eng_Latn"
+
+    with open(f"{temp_output_dir}/metadata.json") as f:
+        metadata = json.load(f)
+    assert metadata["language"] == "eng_Latn"
+
+
+def test_prepare_data_unit_type_chars(temp_output_dir, monkeypatch):
+    """Test that --unit_type chars counts characters instead of words."""
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "welt-prepare-data",
+            "--dataset_name", "wikitext",
+            "--dataset_config", "wikitext-2-raw-v1",
+            "--max_total_units", "500",
+            "--unit_type", "chars",
+            "--seed", "42",
+            "--output_path", temp_output_dir,
+        ],
+    )
+    main()
+
+    with open(f"{temp_output_dir}/metadata.json") as f:
+        metadata = json.load(f)
+    assert metadata["unit_type"] == "chars"
+    assert metadata["total_units"] <= 500
+
+
+def test_prepare_data_with_max_seq_length(temp_output_dir, monkeypatch):
+    """Test that --max_seq_length splits long documents into chunks."""
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "welt-prepare-data",
+            "--dataset_name", "wikitext",
+            "--dataset_config", "wikitext-2-raw-v1",
+            "--max_total_units", "500",
+            "--max_seq_length", "32",
+            "--seed", "42",
+            "--output_path", temp_output_dir,
+        ],
+    )
+    main()
+
+    with open(f"{temp_output_dir}/metadata.json") as f:
+        metadata = json.load(f)
+    assert metadata["max_seq_length"] == 32
+    assert metadata["total_units"] <= 500
+
+    # Verify each example has at most max_seq_length words
+    from words_segmentation.tokenizer import WordsSegmentationTokenizer
+    pretokenizer = WordsSegmentationTokenizer()
+
+    shard_files = sorted(glob.glob(f"{temp_output_dir}/*.jsonl.gz"))
+    for path in shard_files:
+        with gzip.open(path, "rt") as f:
+            for line in f:
+                example = json.loads(line)
+                words = pretokenizer.tokenize(example["text"])
+                assert len(words) <= 32

--- a/tests/test_verify_data.py
+++ b/tests/test_verify_data.py
@@ -1,0 +1,127 @@
+import gzip
+import json
+import shutil
+import tempfile
+
+import pytest
+
+from welt_training.verify_data import verify
+
+
+@pytest.fixture
+def temp_dir():
+    d = tempfile.mkdtemp(prefix="test_verify_data_")
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+def write_metadata(path, metadata):
+    with open(path, "w") as f:
+        json.dump(metadata, f)
+
+
+def write_shard(path, examples):
+    with gzip.open(path, "wt") as f:
+        for ex in examples:
+            f.write(json.dumps(ex) + "\n")
+
+
+def make_metadata(split, num_examples, num_shards, **overrides):
+    base = {
+        "format": "welt-preprocessed-v1",
+        "split": split,
+        "num_examples": num_examples,
+        "num_shards": num_shards,
+        "total_units": num_examples * 10,
+        "unit_type": "words",
+        "source_dataset": "test-dataset",
+        "source_config": "test-config",
+        "source_split": "train",
+        "language": "eng_Latn",
+        "max_seq_length": None,
+        "seed": 42,
+        "text_column": "text",
+        "text_template": None,
+        "created_with_another_split": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_verify_empty_dir(temp_dir):
+    passed, messages = verify(temp_dir)
+    assert not passed
+    assert any("No" in m for m in messages)
+
+
+def test_verify_consistent_single_split(temp_dir):
+    examples = [{"text": f"example {i}"} for i in range(5)]
+    write_shard(f"{temp_dir}/ds-train-00000000.jsonl.gz", examples)
+    write_metadata(f"{temp_dir}/ds-train-metadata.json", make_metadata("train", 5, 1))
+
+    passed, messages = verify(temp_dir)
+    assert passed
+
+
+def test_verify_shard_count_mismatch(temp_dir):
+    examples = [{"text": "hello"}]
+    write_shard(f"{temp_dir}/ds-train-00000000.jsonl.gz", examples)
+    write_metadata(f"{temp_dir}/ds-train-metadata.json", make_metadata("train", 1, 2))
+
+    passed, messages = verify(temp_dir)
+    assert not passed
+    assert any("Expected 2 shards" in m for m in messages)
+
+
+def test_verify_example_count_mismatch(temp_dir):
+    examples = [{"text": "hello"}, {"text": "world"}]
+    write_shard(f"{temp_dir}/ds-train-00000000.jsonl.gz", examples)
+    write_metadata(f"{temp_dir}/ds-train-metadata.json", make_metadata("train", 5, 1))
+
+    passed, messages = verify(temp_dir)
+    assert not passed
+    assert any("Expected 5 examples" in m for m in messages)
+
+
+def test_verify_contamination_warning(temp_dir):
+    """Splits from same source created separately should warn."""
+    write_shard(f"{temp_dir}/ds-train-00000000.jsonl.gz", [{"text": "a"}])
+    write_shard(f"{temp_dir}/ds-validation-00000000.jsonl.gz", [{"text": "b"}])
+    write_metadata(f"{temp_dir}/ds-train-metadata.json",
+                   make_metadata("train", 1, 1, created_with_another_split=False))
+    write_metadata(f"{temp_dir}/ds-validation-metadata.json",
+                   make_metadata("validation", 1, 1, created_with_another_split=False))
+
+    passed, messages = verify(temp_dir)
+    assert passed  # warning, not failure
+    assert any("WARN" in m and "overlap" in m for m in messages)
+
+
+def test_verify_no_contamination_when_created_together(temp_dir):
+    """Splits created together should pass contamination check."""
+    write_shard(f"{temp_dir}/ds-train-00000000.jsonl.gz", [{"text": "a"}])
+    write_shard(f"{temp_dir}/ds-validation-00000000.jsonl.gz", [{"text": "b"}])
+    write_metadata(f"{temp_dir}/ds-train-metadata.json",
+                   make_metadata("train", 1, 1, created_with_another_split=True))
+    write_metadata(f"{temp_dir}/ds-validation-metadata.json",
+                   make_metadata("validation", 1, 1, created_with_another_split=True))
+
+    passed, messages = verify(temp_dir)
+    assert passed
+    assert any("no overlap" in m for m in messages)
+
+
+def test_verify_no_contamination_different_sources(temp_dir):
+    """Splits from different sources should skip contamination check."""
+    write_shard(f"{temp_dir}/ds1-train-00000000.jsonl.gz", [{"text": "a"}])
+    write_shard(f"{temp_dir}/ds2-validation-00000000.jsonl.gz", [{"text": "b"}])
+    write_metadata(f"{temp_dir}/ds1-train-metadata.json",
+                   make_metadata("train", 1, 1, source_dataset="dataset-A"))
+    write_metadata(f"{temp_dir}/ds2-validation-metadata.json",
+                   make_metadata("validation", 1, 1, source_dataset="dataset-B"))
+
+    passed, messages = verify(temp_dir)
+    assert passed
+    # No contamination message since sources differ
+    assert not any("overlap" in m for m in messages)
+    assert not any("contamination" in m for m in messages)

--- a/welt_training/args_data.py
+++ b/welt_training/args_data.py
@@ -96,9 +96,9 @@ class DataTrainingArguments:
     keep_linebreaks: bool = field(
         default=True, metadata={"help": "Whether to keep line breaks when using TXT files or not."}
     )
-    preprocessed_data_path: str | None = field(
+    prepared_data_path: str | None = field(
         default=None,
-        metadata={"help": "Path to preprocessed dataset (from welt-prepare-data). Skips download and pretokenization."},
+        metadata={"help": "Path to prepared dataset shards (from welt-prepare-data). Skips download and text extraction."},
     )
 
     def __post_init__(self):
@@ -125,9 +125,9 @@ class DataTrainingArguments:
             self.dataset_name is None
             and self.train_file is None
             and self.validation_file is None
-            and self.preprocessed_data_path is None
+            and self.prepared_data_path is None
         ):
-            raise ValueError("Need either a dataset name, a training/validation file, or a preprocessed data path.")
+            raise ValueError("Need either a dataset name, a training/validation file, or a prepared data path.")
         else:
             if self.train_file is not None:
                 extension = self.train_file.split(".")[-1]

--- a/welt_training/args_data.py
+++ b/welt_training/args_data.py
@@ -96,6 +96,10 @@ class DataTrainingArguments:
     keep_linebreaks: bool = field(
         default=True, metadata={"help": "Whether to keep line breaks when using TXT files or not."}
     )
+    preprocessed_data_path: str | None = field(
+        default=None,
+        metadata={"help": "Path to preprocessed dataset (from welt-prepare-data). Skips download and pretokenization."},
+    )
 
     def __post_init__(self):
         if self.streaming:
@@ -117,8 +121,13 @@ class DataTrainingArguments:
                 )
                 raise ValueError(msg)
 
-        if self.dataset_name is None and self.train_file is None and self.validation_file is None:
-            raise ValueError("Need either a dataset name or a training/validation file.")
+        if (
+            self.dataset_name is None
+            and self.train_file is None
+            and self.validation_file is None
+            and self.preprocessed_data_path is None
+        ):
+            raise ValueError("Need either a dataset name, a training/validation file, or a preprocessed data path.")
         else:
             if self.train_file is not None:
                 extension = self.train_file.split(".")[-1]

--- a/welt_training/args_data.py
+++ b/welt_training/args_data.py
@@ -98,7 +98,9 @@ class DataTrainingArguments:
     )
     prepared_data_path: str | None = field(
         default=None,
-        metadata={"help": "Path to prepared dataset shards (from welt-prepare-data). Skips download and text extraction."},
+        metadata={
+            "help": "Path to prepared dataset shards (from welt-prepare-data). Skips download and text extraction."
+        },
     )
 
     def __post_init__(self):

--- a/welt_training/data_utils.py
+++ b/welt_training/data_utils.py
@@ -1,0 +1,32 @@
+import glob
+import logging
+import os
+
+from datasets import load_dataset
+
+logger = logging.getLogger(__name__)
+
+
+def load_prepared_data(prepared_data_path: str, validation_split_percentage: int | None = None, seed: int = 42):
+    """Load preprocessed shards produced by prepare_data.py.
+
+    Args:
+        prepared_data_path: Directory containing ``*.jsonl.gz`` shard files.
+        validation_split_percentage: If set, split the data into train/validation.
+        seed: Random seed for the train/test split.
+
+    Returns:
+        A dict with ``"train"`` (and optionally ``"validation"``) datasets.
+    """
+    data_files = sorted(glob.glob(os.path.join(prepared_data_path, "*.jsonl.gz")))
+    if not data_files:
+        raise ValueError(f"No .jsonl.gz files found in {prepared_data_path}")
+    logger.info(f"Loading prepared data from {len(data_files)} shard(s) in {prepared_data_path}")
+    train_data = load_dataset("json", data_files=data_files, split="train")
+
+    if validation_split_percentage:
+        split = train_data.train_test_split(
+            test_size=validation_split_percentage / 100, seed=seed
+        )
+        return {"train": split["train"], "validation": split["test"]}
+    return {"train": train_data}

--- a/welt_training/data_utils.py
+++ b/welt_training/data_utils.py
@@ -7,54 +7,40 @@ from datasets import load_dataset
 logger = logging.getLogger(__name__)
 
 
-def load_prepared_data(prepared_data_path: str, validation_split_percentage: int | None = None, seed: int = 42):
+def load_prepared_data(prepared_data_path: str):
     """Load preprocessed shards produced by prepare_data.py.
 
-    Supports two shard naming conventions:
+    Loads ``{prefix}-train-*.jsonl.gz`` shards as the train split and
+    ``{prefix}-validation-*.jsonl.gz`` shards as the validation split.
 
-    - **Split-aware** (preferred): Files named ``{prefix}-train-*.jsonl.gz``
-      and ``{prefix}-validation-*.jsonl.gz``.  Train and validation datasets
-      are loaded directly from their respective shards, ensuring each source
-      dataset contributes proportionally to both splits.  The
-      ``validation_split_percentage`` parameter is ignored in this mode.
-
-    - **Legacy**: Files named ``{prefix}-*.jsonl.gz`` without split markers.
-      A random ``train_test_split`` is applied using
-      ``validation_split_percentage``.
+    Both train and validation shards are required. Prepare data with
+    ``--validation_split_units`` to produce them.
 
     Args:
         prepared_data_path: Directory containing ``*.jsonl.gz`` shard files.
-        validation_split_percentage: If set, split the data into train/validation
-            (only used for legacy shards without split markers).
-        seed: Random seed for the train/test split (legacy mode only).
 
     Returns:
-        A dict with ``"train"`` (and optionally ``"validation"``) datasets.
+        A dict with ``"train"`` and ``"validation"`` datasets.
     """
-    # Check for split-aware files produced with --validation_split_percentage
     train_files = sorted(glob.glob(os.path.join(prepared_data_path, "*-train-*.jsonl.gz")))
     validation_files = sorted(glob.glob(os.path.join(prepared_data_path, "*-validation-*.jsonl.gz")))
 
-    if train_files:
-        logger.info(
-            f"Loading split-aware data: {len(train_files)} train shard(s), "
-            f"{len(validation_files)} validation shard(s) from {prepared_data_path}"
+    if not train_files:
+        raise ValueError(
+            f"No *-train-*.jsonl.gz files found in {prepared_data_path}. "
+            "Prepare data with --train_split_units and --validation_split_units."
         )
-        result = {"train": load_dataset("json", data_files=train_files, split="train")}
-        if validation_files:
-            result["validation"] = load_dataset("json", data_files=validation_files, split="train")
-        return result
-
-    # Legacy mode: all shards in a single pool
-    data_files = sorted(glob.glob(os.path.join(prepared_data_path, "*.jsonl.gz")))
-    if not data_files:
-        raise ValueError(f"No .jsonl.gz files found in {prepared_data_path}")
-    logger.info(f"Loading prepared data from {len(data_files)} shard(s) in {prepared_data_path}")
-    train_data = load_dataset("json", data_files=data_files, split="train")
-
-    if validation_split_percentage:
-        split = train_data.train_test_split(
-            test_size=validation_split_percentage / 100, seed=seed
+    if not validation_files:
+        raise ValueError(
+            f"No *-validation-*.jsonl.gz files found in {prepared_data_path}. "
+            "Prepare data with --validation_split_units to create a validation split."
         )
-        return {"train": split["train"], "validation": split["test"]}
-    return {"train": train_data}
+
+    logger.info(
+        f"Loading prepared data: {len(train_files)} train shard(s), "
+        f"{len(validation_files)} validation shard(s) from {prepared_data_path}"
+    )
+    return {
+        "train": load_dataset("json", data_files=train_files, split="train"),
+        "validation": load_dataset("json", data_files=validation_files, split="train"),
+    }

--- a/welt_training/data_utils.py
+++ b/welt_training/data_utils.py
@@ -10,14 +10,42 @@ logger = logging.getLogger(__name__)
 def load_prepared_data(prepared_data_path: str, validation_split_percentage: int | None = None, seed: int = 42):
     """Load preprocessed shards produced by prepare_data.py.
 
+    Supports two shard naming conventions:
+
+    - **Split-aware** (preferred): Files named ``{prefix}-train-*.jsonl.gz``
+      and ``{prefix}-validation-*.jsonl.gz``.  Train and validation datasets
+      are loaded directly from their respective shards, ensuring each source
+      dataset contributes proportionally to both splits.  The
+      ``validation_split_percentage`` parameter is ignored in this mode.
+
+    - **Legacy**: Files named ``{prefix}-*.jsonl.gz`` without split markers.
+      A random ``train_test_split`` is applied using
+      ``validation_split_percentage``.
+
     Args:
         prepared_data_path: Directory containing ``*.jsonl.gz`` shard files.
-        validation_split_percentage: If set, split the data into train/validation.
-        seed: Random seed for the train/test split.
+        validation_split_percentage: If set, split the data into train/validation
+            (only used for legacy shards without split markers).
+        seed: Random seed for the train/test split (legacy mode only).
 
     Returns:
         A dict with ``"train"`` (and optionally ``"validation"``) datasets.
     """
+    # Check for split-aware files produced with --validation_split_percentage
+    train_files = sorted(glob.glob(os.path.join(prepared_data_path, "*-train-*.jsonl.gz")))
+    validation_files = sorted(glob.glob(os.path.join(prepared_data_path, "*-validation-*.jsonl.gz")))
+
+    if train_files:
+        logger.info(
+            f"Loading split-aware data: {len(train_files)} train shard(s), "
+            f"{len(validation_files)} validation shard(s) from {prepared_data_path}"
+        )
+        result = {"train": load_dataset("json", data_files=train_files, split="train")}
+        if validation_files:
+            result["validation"] = load_dataset("json", data_files=validation_files, split="train")
+        return result
+
+    # Legacy mode: all shards in a single pool
     data_files = sorted(glob.glob(os.path.join(prepared_data_path, "*.jsonl.gz")))
     if not data_files:
         raise ValueError(f"No .jsonl.gz files found in {prepared_data_path}")

--- a/welt_training/data_utils.py
+++ b/welt_training/data_utils.py
@@ -7,6 +7,13 @@ from datasets import load_dataset
 logger = logging.getLogger(__name__)
 
 
+def extract_text(example: dict, text_column: str = "text", text_template: str | None = None) -> str:
+    """Extract text from a dataset example using a column name or format template."""
+    if text_template is not None:
+        return text_template.format(**example)
+    return example[text_column]
+
+
 def load_prepared_data(prepared_data_path: str):
     """Load preprocessed shards produced by prepare_data.py.
 

--- a/welt_training/data_utils.py
+++ b/welt_training/data_utils.py
@@ -17,37 +17,34 @@ def extract_text(example: dict, text_column: str = "text", text_template: str | 
 def load_prepared_data(prepared_data_path: str):
     """Load preprocessed shards produced by prepare_data.py.
 
-    Loads ``{prefix}-train-*.jsonl.gz`` shards as the train split and
+    Loads ``{prefix}-train-*.jsonl.gz`` shards as the train split and/or
     ``{prefix}-validation-*.jsonl.gz`` shards as the validation split.
 
-    Both train and validation shards are required. Prepare data with
-    ``--validation_split_units`` to produce them.
+    At least one split must be present. Missing splits are omitted from the result.
 
     Args:
         prepared_data_path: Directory containing ``*.jsonl.gz`` shard files.
 
     Returns:
-        A dict with ``"train"`` and ``"validation"`` datasets.
+        A dict with ``"train"`` and/or ``"validation"`` datasets.
     """
     train_files = sorted(glob.glob(os.path.join(prepared_data_path, "*-train-*.jsonl.gz")))
     validation_files = sorted(glob.glob(os.path.join(prepared_data_path, "*-validation-*.jsonl.gz")))
 
-    if not train_files:
+    if not train_files and not validation_files:
         raise ValueError(
-            f"No *-train-*.jsonl.gz files found in {prepared_data_path}. "
-            "Prepare data with --train_split_units and --validation_split_units."
+            f"No *-train-*.jsonl.gz or *-validation-*.jsonl.gz files found in {prepared_data_path}. "
+            "Prepare data with --train_split_units and/or --validation_split_units."
         )
-    if not validation_files:
-        raise ValueError(
-            f"No *-validation-*.jsonl.gz files found in {prepared_data_path}. "
-            "Prepare data with --validation_split_units to create a validation split."
-        )
+
+    result = {}
+    if train_files:
+        result["train"] = load_dataset("json", data_files=train_files, split="train")
+    if validation_files:
+        result["validation"] = load_dataset("json", data_files=validation_files, split="train")
 
     logger.info(
         f"Loading prepared data: {len(train_files)} train shard(s), "
         f"{len(validation_files)} validation shard(s) from {prepared_data_path}"
     )
-    return {
-        "train": load_dataset("json", data_files=train_files, split="train"),
-        "validation": load_dataset("json", data_files=validation_files, split="train"),
-    }
+    return result

--- a/welt_training/data_utils.py
+++ b/welt_training/data_utils.py
@@ -14,6 +14,11 @@ def extract_text(example: dict, text_column: str = "text", text_template: str | 
     return example[text_column]
 
 
+def find_shard_files(data_path: str, split_name: str) -> list[str]:
+    """Return sorted shard files for a given split in a prepared data directory."""
+    return sorted(glob.glob(os.path.join(data_path, f"*-{split_name}-*.jsonl.gz")))
+
+
 def load_prepared_data(prepared_data_path: str):
     """Load preprocessed shards produced by prepare_data.py.
 
@@ -28,8 +33,8 @@ def load_prepared_data(prepared_data_path: str):
     Returns:
         A dict with ``"train"`` and/or ``"validation"`` datasets.
     """
-    train_files = sorted(glob.glob(os.path.join(prepared_data_path, "*-train-*.jsonl.gz")))
-    validation_files = sorted(glob.glob(os.path.join(prepared_data_path, "*-validation-*.jsonl.gz")))
+    train_files = find_shard_files(prepared_data_path, "train")
+    validation_files = find_shard_files(prepared_data_path, "validation")
 
     if not train_files and not validation_files:
         raise ValueError(

--- a/welt_training/data_utils.py
+++ b/welt_training/data_utils.py
@@ -14,9 +14,15 @@ def extract_text(example: dict, text_column: str = "text", text_template: str | 
     return example[text_column]
 
 
-def find_shard_files(data_path: str, split_name: str) -> list[str]:
-    """Return sorted shard files for a given split in a prepared data directory."""
-    return sorted(glob.glob(os.path.join(data_path, f"*-{split_name}-*.jsonl.gz")))
+def find_shard_files(data_path: str, split_name: str, prefix: str | None = None) -> list[str]:
+    """Return sorted shard files for a given split in a prepared data directory.
+
+    When *prefix* is given, only shards for that specific dataset are matched.
+    Without it, shards from all datasets in the directory are returned (used by
+    :func:`load_prepared_data` to load multi-dataset mixtures).
+    """
+    name = f"{prefix}-{split_name}" if prefix else f"*-{split_name}"
+    return sorted(glob.glob(os.path.join(data_path, f"{name}-*.jsonl.gz")))
 
 
 def load_prepared_data(prepared_data_path: str):

--- a/welt_training/experiments/machine-translation/run_clm.py
+++ b/welt_training/experiments/machine-translation/run_clm.py
@@ -378,11 +378,9 @@ def main():
     # In distributed training, the load_dataset function guarantee that only one local process can concurrently
     # download the dataset.
     if data_args.prepared_data_path is not None:
-        raw_datasets = load_prepared_data(
-            data_args.prepared_data_path,
-            validation_split_percentage=data_args.validation_split_percentage,
-            seed=training_args.seed,
-        )
+        if data_args.validation_split_percentage is not None:
+            logger.warning("Ignoring validation_split_percentage because prepared_data_path is set.")
+        raw_datasets = load_prepared_data(data_args.prepared_data_path)
 
     elif data_args.dataset_name is not None:
         # Downloading and loading a dataset from the hub.

--- a/welt_training/experiments/machine-translation/run_clm.py
+++ b/welt_training/experiments/machine-translation/run_clm.py
@@ -48,7 +48,7 @@ from typing import Optional
 import datasets
 import evaluate
 import torch
-from datasets import IterableDataset, IterableDatasetDict, load_dataset
+from datasets import DatasetDict, IterableDataset, IterableDatasetDict, load_dataset
 
 import transformers
 from transformers import (
@@ -318,6 +318,8 @@ def main():
         # If we pass only one argument to the script and it's the path to a json file,
         # let's parse it to get our arguments.
         model_args, data_args, training_args = parser.parse_json_file(json_file=os.path.abspath(sys.argv[1]))
+    elif len(sys.argv) == 2 and sys.argv[1].endswith((".yaml", ".yml")):
+        model_args, data_args, training_args = parser.parse_yaml_file(yaml_file=os.path.abspath(sys.argv[1]))
     else:
         model_args, data_args, training_args = parser.parse_args_into_dataclasses()
 
@@ -380,7 +382,7 @@ def main():
     if data_args.prepared_data_path is not None:
         if data_args.validation_split_percentage is not None:
             logger.warning("Ignoring validation_split_percentage because prepared_data_path is set.")
-        raw_datasets = load_prepared_data(data_args.prepared_data_path)
+        raw_datasets = DatasetDict(load_prepared_data(data_args.prepared_data_path))
 
     elif data_args.dataset_name is not None:
         # Downloading and loading a dataset from the hub.
@@ -566,6 +568,7 @@ def main():
         desc="Keep only the text column & apply template",
         **map_args
     )
+    column_names = [text_column_name]
 
 
     def tokenize_function(examples):

--- a/welt_training/prepare_data.py
+++ b/welt_training/prepare_data.py
@@ -196,7 +196,7 @@ def main():
     num_examples = 0
 
     def open_shard(index: int):
-        path = output_path / f"{prefix}-{index:05d}.jsonl.gz"
+        path = output_path / f"{prefix}-{index:08d}.jsonl.gz"
         logger.info(f"Writing shard: {path.name}")
         return gzip.open(path, "wt")
 
@@ -233,7 +233,7 @@ def main():
     current_file.close()
 
     # Remove empty last shard
-    last_shard_path = output_path / f"{prefix}-{shard_index:05d}.jsonl.gz"
+    last_shard_path = output_path / f"{prefix}-{shard_index:08d}.jsonl.gz"
     if shard_units == 0 and shard_index > 0:
         last_shard_path.unlink()
         shard_index -= 1

--- a/welt_training/prepare_data.py
+++ b/welt_training/prepare_data.py
@@ -144,6 +144,13 @@ def main():
         help="Max words per example. Long documents are split using word segmentation.",
     )
     parser.add_argument(
+        "--max_bytes_per_word",
+        type=int,
+        default=126,
+        help="Max UTF-8 bytes per word. Words exceeding this are split. "
+             "Should match training config: max_word_length - 2 (default: 128 - 2 = 126).",
+    )
+    parser.add_argument(
         "--drop_remainder",
         action="store_true",
         help="Drop partial chunks when splitting documents by max_seq_length",
@@ -183,7 +190,7 @@ def main():
     output_path.mkdir(parents=True, exist_ok=True)
 
     prefix = get_shard_prefix(args.dataset_name, args.dataset_config)
-    pretokenizer = WordsSegmentationTokenizer()
+    pretokenizer = WordsSegmentationTokenizer(max_bytes=args.max_bytes_per_word)
 
     logger.info("Starting data preparation...")
     logger.info(f"  unit_type={args.unit_type}, max_total_units={args.max_total_units}, "
@@ -239,6 +246,9 @@ def main():
         shard_index -= 1
 
     num_shards = shard_index + 1
+
+    if num_examples == 0:
+        logger.warning("No examples were written. Check dataset and filter settings.")
 
     # Save metadata
     metadata = {

--- a/welt_training/prepare_data.py
+++ b/welt_training/prepare_data.py
@@ -14,6 +14,8 @@ from pathlib import Path
 from datasets import load_dataset
 from words_segmentation.tokenizer import WordsSegmentationTokenizer
 
+from welt_training.data_utils import extract_text
+
 logger = logging.getLogger(__name__)
 
 
@@ -96,11 +98,7 @@ def stream_texts(args):
     stream = stream.shuffle(seed=args.seed, buffer_size=args.shuffle_buffer_size)
 
     for example in stream:
-        if args.text_template:
-            text = args.text_template.format(**example)
-        else:
-            text = example[args.text_column]
-
+        text = extract_text(example, text_column=args.text_column, text_template=args.text_template)
         if text:
             yield text
 

--- a/welt_training/prepare_data.py
+++ b/welt_training/prepare_data.py
@@ -75,6 +75,7 @@ class ShardWriter:
     def close(self):
         if self._current_file is not None:
             self._current_file.close()
+            self._current_file = None
             self._num_shards += 1
 
     def __enter__(self):
@@ -296,11 +297,9 @@ def main():
                 logger.info(f"Reached total units limit ({max_total_units})")
                 break
 
-            record = {"text": text}
+            record = {"text": text, "language": args.language}
             if id_value is not None:
                 record["id"] = id_value
-            if args.language:
-                record["language"] = args.language
 
             # Fill validation first, then route to train
             if val_writer.total_units < args.validation_split_units:

--- a/welt_training/prepare_data.py
+++ b/welt_training/prepare_data.py
@@ -1,0 +1,273 @@
+"""
+Data preparation script for offline use.
+
+Downloads HuggingFace datasets, samples raw text with unit-based limits,
+and saves sharded .jsonl.gz files for offline training.
+"""
+
+import argparse
+import gzip
+import json
+import logging
+from pathlib import Path
+
+from datasets import load_dataset
+from words_segmentation.tokenizer import WordsSegmentationTokenizer
+
+logger = logging.getLogger(__name__)
+
+
+def get_shard_prefix(dataset_name: str, dataset_config: str | None) -> str:
+    """Derive a shard filename prefix from dataset name and config."""
+    name = dataset_name.split("/")[-1]
+    if dataset_config:
+        return f"{name}-{dataset_config}"
+    return name
+
+
+def stream_texts(args):
+    """Stream raw text examples from a HuggingFace dataset."""
+    load_kwargs = {
+        "path": args.dataset_name,
+        "split": args.dataset_split,
+        "streaming": True,
+    }
+    if args.dataset_config:
+        load_kwargs["name"] = args.dataset_config
+
+    logger.info(f"Loading dataset: {args.dataset_name} (config: {args.dataset_config}, split: {args.dataset_split})")
+    stream = load_dataset(**load_kwargs)
+
+    # Shuffle with seed
+    stream = stream.shuffle(seed=args.seed, buffer_size=args.shuffle_buffer_size)
+
+    for example in stream:
+        if args.text_template:
+            text = args.text_template.format(**example)
+        else:
+            text = example[args.text_column]
+
+        if text:
+            yield text
+
+
+def stream_examples(args, pretokenizer: WordsSegmentationTokenizer):
+    """Stream text examples, optionally chunked by max_seq_length.
+
+    Uses word segmentation to split text into words (handles Thai and other
+    languages without whitespace). When max_seq_length is set, long documents
+    are split into chunks of at most max_seq_length words.
+
+    Yields (text, num_words) tuples.
+    """
+    for text in stream_texts(args):
+        words = pretokenizer.tokenize(text)
+
+        if args.max_seq_length is None:
+            yield text, len(words)
+            continue
+
+        for i in range(0, len(words), args.max_seq_length):
+            chunk_words = words[i:i + args.max_seq_length]
+            if args.drop_remainder and len(chunk_words) < args.max_seq_length:
+                continue
+            yield "".join(chunk_words), len(chunk_words)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Prepare HuggingFace datasets for offline training."
+    )
+
+    # Dataset arguments
+    parser.add_argument(
+        "--dataset_name",
+        type=str,
+        required=True,
+        help="HuggingFace dataset identifier (required)",
+    )
+    parser.add_argument(
+        "--dataset_config",
+        type=str,
+        default=None,
+        help="Dataset config name (optional)",
+    )
+    parser.add_argument(
+        "--dataset_split",
+        type=str,
+        default="train",
+        help="Split to use (default: 'train')",
+    )
+    parser.add_argument(
+        "--text_column",
+        type=str,
+        default="text",
+        help="Column containing text (default: 'text')",
+    )
+    parser.add_argument(
+        "--text_template",
+        type=str,
+        default=None,
+        help="Python format string template (optional)",
+    )
+    parser.add_argument(
+        "--language",
+        type=str,
+        default=None,
+        help="Language tag to store with each example (e.g., 'eng_Latn')",
+    )
+
+    # Processing arguments
+    parser.add_argument(
+        "--unit_type",
+        type=str,
+        choices=["words", "chars"],
+        default="words",
+        help="Unit type for counting (default: 'words')",
+    )
+    parser.add_argument(
+        "--max_total_units",
+        type=int,
+        default=None,
+        help="Max total units to sample. If not set, processes the entire dataset.",
+    )
+    parser.add_argument(
+        "--num_units_per_file",
+        type=int,
+        default=None,
+        help="Max units per shard file. If not set, all data goes into one file.",
+    )
+    parser.add_argument(
+        "--max_seq_length",
+        type=int,
+        default=None,
+        help="Max words per example. Long documents are split using word segmentation.",
+    )
+    parser.add_argument(
+        "--drop_remainder",
+        action="store_true",
+        help="Drop partial chunks when splitting documents by max_seq_length",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed for shuffling",
+    )
+    parser.add_argument(
+        "--shuffle_buffer_size",
+        type=int,
+        default=10000,
+        help="Buffer size for streaming shuffle (default: 10000)",
+    )
+
+    # Output arguments
+    parser.add_argument(
+        "--output_path",
+        type=str,
+        required=True,
+        help="Output directory path (required)",
+    )
+
+    args = parser.parse_args()
+
+    # Setup logging
+    logging.basicConfig(
+        format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+        datefmt="%m/%d/%Y %H:%M:%S",
+        level=logging.INFO,
+    )
+
+    # Create output directory
+    output_path = Path(args.output_path)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    prefix = get_shard_prefix(args.dataset_name, args.dataset_config)
+    pretokenizer = WordsSegmentationTokenizer()
+
+    logger.info("Starting data preparation...")
+    logger.info(f"  unit_type={args.unit_type}, max_total_units={args.max_total_units}, "
+                f"num_units_per_file={args.num_units_per_file}, max_seq_length={args.max_seq_length}, "
+                f"language={args.language}")
+
+    shard_index = 0
+    shard_units = 0
+    total_units = 0
+    num_examples = 0
+
+    def open_shard(index: int):
+        path = output_path / f"{prefix}-{index:05d}.jsonl.gz"
+        logger.info(f"Writing shard: {path.name}")
+        return gzip.open(path, "wt")
+
+    current_file = open_shard(shard_index)
+
+    for text, num_words in stream_examples(args, pretokenizer):
+        text_units = num_words if args.unit_type == "words" else len(text)
+
+        # Check global limit
+        if args.max_total_units is not None and total_units + text_units > args.max_total_units:
+            logger.info(f"Reached max_total_units limit ({args.max_total_units})")
+            break
+
+        record = {"text": text}
+        if args.language:
+            record["language"] = args.language
+
+        current_file.write(json.dumps(record, ensure_ascii=False) + "\n")
+        shard_units += text_units
+        total_units += text_units
+        num_examples += 1
+
+        if num_examples % 10000 == 0:
+            logger.info(f"Processed {num_examples} examples, {total_units} total {args.unit_type}")
+
+        # Check shard limit
+        if args.num_units_per_file is not None and shard_units >= args.num_units_per_file:
+            current_file.close()
+            logger.info(f"Completed shard {shard_index} ({shard_units} {args.unit_type})")
+            shard_index += 1
+            shard_units = 0
+            current_file = open_shard(shard_index)
+
+    current_file.close()
+
+    # Remove empty last shard
+    last_shard_path = output_path / f"{prefix}-{shard_index:05d}.jsonl.gz"
+    if shard_units == 0 and shard_index > 0:
+        last_shard_path.unlink()
+        shard_index -= 1
+
+    num_shards = shard_index + 1
+
+    # Save metadata
+    metadata = {
+        "format": "welt-preprocessed-v1",
+        "num_examples": num_examples,
+        "total_units": total_units,
+        "unit_type": args.unit_type,
+        "num_shards": num_shards,
+        "source_dataset": args.dataset_name,
+        "source_config": args.dataset_config,
+        "source_split": args.dataset_split,
+        "language": args.language,
+        "max_seq_length": args.max_seq_length,
+        "seed": args.seed,
+        "text_column": args.text_column,
+        "text_template": args.text_template,
+    }
+
+    metadata_path = output_path / f"{prefix}-metadata.json"
+    logger.info(f"Saving metadata to {metadata_path}")
+    with open(metadata_path, "w") as f:
+        json.dump(metadata, f, indent=2)
+
+    logger.info("Data preparation complete!")
+    logger.info(f"  - Examples: {num_examples}")
+    logger.info(f"  - Total {args.unit_type}: {total_units}")
+    logger.info(f"  - Shards: {num_shards}")
+    logger.info(f"  - Output: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/welt_training/train.py
+++ b/welt_training/train.py
@@ -161,8 +161,7 @@ def detect_last_checkpoint(training_args: TrainingArguments):
 def init_datasets(data_args: DataTrainingArguments,  # noqa: C901
                   trust_remote_code: bool,
                   do_train: bool = True,
-                  cache_dir: str = None,
-                  seed: int = 42):
+                  cache_dir: str = None):
     # Get the datasets: you can either provide your own CSV/JSON/TXT training and evaluation files (see below)
     # or just provide the name of one of the public datasets available on the hub at https://huggingface.co/datasets/
     # (the dataset will be downloaded automatically from the datasets Hub).
@@ -374,8 +373,7 @@ def train(args: list[str] | None | str = None):  # noqa: C901
     text_datasets = init_datasets(data_args,
                                   cache_dir=cache_dir,
                                   trust_remote_code=model_args.trust_remote_code,
-                                  do_train=training_args.do_train,
-                                  seed=training_args.seed)
+                                  do_train=training_args.do_train)
 
     train_dataset = None
     if training_args.do_train:

--- a/welt_training/train.py
+++ b/welt_training/train.py
@@ -161,7 +161,8 @@ def detect_last_checkpoint(training_args: TrainingArguments):
 def init_datasets(data_args: DataTrainingArguments,  # noqa: C901
                   trust_remote_code: bool,
                   do_train: bool = True,
-                  cache_dir: str = None):
+                  cache_dir: str = None,
+                  seed: int = 42):
     # Get the datasets: you can either provide your own CSV/JSON/TXT training and evaluation files (see below)
     # or just provide the name of one of the public datasets available on the hub at https://huggingface.co/datasets/
     # (the dataset will be downloaded automatically from the datasets Hub).
@@ -186,7 +187,7 @@ def init_datasets(data_args: DataTrainingArguments,  # noqa: C901
         # Create validation split if needed
         if data_args.validation_split_percentage:
             split = train_data.train_test_split(
-                test_size=data_args.validation_split_percentage / 100, seed=42
+                test_size=data_args.validation_split_percentage / 100, seed=seed
             )
             return {"train": split["train"], "validation": split["test"]}
         return {"train": train_data}
@@ -383,7 +384,8 @@ def train(args: list[str] | None | str = None):  # noqa: C901
     text_datasets = init_datasets(data_args,
                                   cache_dir=cache_dir,
                                   trust_remote_code=model_args.trust_remote_code,
-                                  do_train=training_args.do_train)
+                                  do_train=training_args.do_train,
+                                  seed=training_args.seed)
 
     train_dataset = None
     if training_args.do_train:

--- a/welt_training/train.py
+++ b/welt_training/train.py
@@ -21,7 +21,7 @@ from welt.model_utils import setup_model
 from welt_training.args_data import DataTrainingArguments
 from welt_training.args_model import ModelArguments
 from welt_training.args_trainer import WeLTTrainingArguments
-from welt_training.data_utils import load_prepared_data
+from welt_training.data_utils import extract_text, load_prepared_data
 from welt_training.extendable_yaml import resolve_yaml_file
 from welt_training.flops_callback import FlopsCallback
 from welt_training.freeze_callback import FreezeWarmupCallback
@@ -287,7 +287,7 @@ def init_datasets(data_args: DataTrainingArguments,  # noqa: C901
         template = data_args.dataset_text_template
         if template is None:
             def mapping_fn(example):
-                return {"text": example[text_column_name]}
+                return {"text": extract_text(example, text_column=text_column_name)}
         else:
             is_single_text_template = isinstance(template, str)
             single_text_template = template \
@@ -295,7 +295,7 @@ def init_datasets(data_args: DataTrainingArguments,  # noqa: C901
 
             def mapping_fn(example):
                 if is_single_text_template or split_name == "train":
-                    return {"text": single_text_template.format(**example)}
+                    return {"text": extract_text(example, text_template=single_text_template)}
 
                 prefix = template[0].format(**example)
                 completion = template[1].format(**example)

--- a/welt_training/train.py
+++ b/welt_training/train.py
@@ -375,6 +375,12 @@ def train(args: list[str] | None | str = None):  # noqa: C901
                                   trust_remote_code=model_args.trust_remote_code,
                                   do_train=training_args.do_train)
 
+    # Drop columns not needed for training (e.g. "language" from prepared data)
+    for split in list(text_datasets):
+        extra_cols = [c for c in text_datasets[split].column_names if c != "text"]
+        if extra_cols:
+            text_datasets[split] = text_datasets[split].remove_columns(extra_cols)
+
     train_dataset = None
     if training_args.do_train:
         if "train" not in text_datasets:

--- a/welt_training/train.py
+++ b/welt_training/train.py
@@ -1,10 +1,10 @@
 # Heavily adapted from
 # https://github.com/huggingface/transformers/edit/main/examples/pytorch/language-modeling/run_clm.py
+import glob
 import logging
 import math
 import os
 import sys
-import glob
 
 import datasets
 import transformers
@@ -177,11 +177,11 @@ def init_datasets(data_args: DataTrainingArguments,  # noqa: C901
     # https://huggingface.co/docs/datasets/loading_datasets.
 
     # Load preprocessed data if path provided
-    if data_args.preprocessed_data_path is not None:
-        data_files = sorted(glob.glob(os.path.join(data_args.preprocessed_data_path, "*.jsonl.gz")))
+    if data_args.prepared_data_path is not None:
+        data_files = sorted(glob.glob(os.path.join(data_args.prepared_data_path, "*.jsonl.gz")))
         if not data_files:
-            raise ValueError(f"No .jsonl.gz files found in {data_args.preprocessed_data_path}")
-        logger.info(f"Loading preprocessed data from {len(data_files)} shard(s) in {data_args.preprocessed_data_path}")
+            raise ValueError(f"No .jsonl.gz files found in {data_args.prepared_data_path}")
+        logger.info(f"Loading prepared data from {len(data_files)} shard(s) in {data_args.prepared_data_path}")
         train_data = load_dataset("json", data_files=data_files, split="train")
 
         # Create validation split if needed

--- a/welt_training/train.py
+++ b/welt_training/train.py
@@ -4,6 +4,7 @@ import logging
 import math
 import os
 import sys
+import glob
 
 import datasets
 import transformers
@@ -176,7 +177,6 @@ def init_datasets(data_args: DataTrainingArguments,  # noqa: C901
 
     # Load preprocessed data if path provided
     if data_args.preprocessed_data_path is not None:
-        import glob
         data_files = sorted(glob.glob(os.path.join(data_args.preprocessed_data_path, "*.jsonl.gz")))
         if not data_files:
             raise ValueError(f"No .jsonl.gz files found in {data_args.preprocessed_data_path}")

--- a/welt_training/train.py
+++ b/welt_training/train.py
@@ -178,11 +178,9 @@ def init_datasets(data_args: DataTrainingArguments,  # noqa: C901
 
     # Load preprocessed data if path provided
     if data_args.prepared_data_path is not None:
-        return load_prepared_data(
-            data_args.prepared_data_path,
-            validation_split_percentage=data_args.validation_split_percentage,
-            seed=seed,
-        )
+        if data_args.validation_split_percentage is not None:
+            logger.warning("Ignoring validation_split_percentage because prepared_data_path is set.")
+        return load_prepared_data(data_args.prepared_data_path)
 
     if data_args.dataset_name is not None:
         # Downloading and loading a dataset from the hub.

--- a/welt_training/verify_data.py
+++ b/welt_training/verify_data.py
@@ -11,6 +11,8 @@ import json
 import os
 import sys
 
+from welt_training.data_utils import find_shard_files
+
 
 def discover_splits(data_path):
     """Find all per-split metadata files and return {split_name: metadata_dict}."""
@@ -48,8 +50,7 @@ def verify(data_path):
 
     # 2. Per-split shard consistency
     for split_name, metadata in splits.items():
-        pattern = os.path.join(data_path, f"*-{split_name}-*.jsonl.gz")
-        shard_files = sorted(glob.glob(pattern))
+        shard_files = find_shard_files(data_path, split_name)
 
         expected_shards = metadata["num_shards"]
         actual_shards = len(shard_files)

--- a/welt_training/verify_data.py
+++ b/welt_training/verify_data.py
@@ -1,0 +1,108 @@
+"""Verify integrity of prepared data directories.
+
+Checks metadata consistency, shard counts, example counts,
+and warns about potential data contamination between splits.
+"""
+
+import argparse
+import glob
+import gzip
+import json
+import os
+import sys
+
+
+def discover_splits(data_path):
+    """Find all per-split metadata files and return {split_name: metadata_dict}."""
+    splits = {}
+    for path in sorted(glob.glob(os.path.join(data_path, "*-metadata.json"))):
+        with open(path) as f:
+            metadata = json.load(f)
+        split_name = metadata["split"]
+        splits[split_name] = metadata
+    return splits
+
+
+def count_shard_examples(shard_files):
+    """Count total examples across a list of .jsonl.gz shard files."""
+    count = 0
+    for path in shard_files:
+        with gzip.open(path, "rt") as f:
+            for _ in f:
+                count += 1
+    return count
+
+
+def verify(data_path):
+    """Run all verification checks. Returns (passed: bool, messages: list[str])."""
+    messages = []
+    passed = True
+
+    # 1. Discover splits
+    splits = discover_splits(data_path)
+    if not splits:
+        messages.append("FAIL: No *-metadata.json files found.")
+        return False, messages
+
+    messages.append(f"Found splits: {', '.join(splits)}")
+
+    # 2. Per-split shard consistency
+    for split_name, metadata in splits.items():
+        pattern = os.path.join(data_path, f"*-{split_name}-*.jsonl.gz")
+        shard_files = sorted(glob.glob(pattern))
+
+        expected_shards = metadata["num_shards"]
+        actual_shards = len(shard_files)
+        if actual_shards != expected_shards:
+            messages.append(
+                f"FAIL [{split_name}]: Expected {expected_shards} shards, found {actual_shards}."
+            )
+            passed = False
+        else:
+            messages.append(f"OK   [{split_name}]: {actual_shards} shard(s)")
+
+        expected_examples = metadata["num_examples"]
+        actual_examples = count_shard_examples(shard_files)
+        if actual_examples != expected_examples:
+            messages.append(
+                f"FAIL [{split_name}]: Expected {expected_examples} examples, found {actual_examples}."
+            )
+            passed = False
+        else:
+            messages.append(f"OK   [{split_name}]: {actual_examples} example(s)")
+
+    # 3. Data contamination check
+    if "train" in splits and "validation" in splits:
+        train_meta = splits["train"]
+        val_meta = splits["validation"]
+        same_source = (
+            train_meta["source_dataset"] == val_meta["source_dataset"]
+            and train_meta["source_config"] == val_meta["source_config"]
+            and train_meta["source_split"] == val_meta["source_split"]
+        )
+        if same_source:
+            if not train_meta.get("created_with_another_split") or not val_meta.get("created_with_another_split"):
+                messages.append(
+                    "WARN: Train and validation share the same source but were not created together. "
+                    "Examples may overlap."
+                )
+            else:
+                messages.append("OK   [contamination]: Splits created together, no overlap risk.")
+
+    return passed, messages
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Verify integrity of prepared data.")
+    parser.add_argument("--data_path", type=str, required=True, help="Path to prepared data directory.")
+    args = parser.parse_args()
+
+    passed, messages = verify(args.data_path)
+    for msg in messages:
+        print(msg)
+
+    sys.exit(0 if passed else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Fixes

Fixes #58 by @ilkerkesen 

## Description

This PR implements a data preparation script, which allows us to create custom pretraining datasets using the specified data resources (i.e., Hugginface dataset). The training script is also adapted to work with the output produces by this script. This PR is critical, as it will enable us to pretrain a model on HPC clusters without internet access.

## Technical details

The implemented script takes a Huggingface dataset as an input, streams the shuffled data, create a compressed shard of `*.jsonl.gz` file when hits the maximum number of words per shard limit, and stop when exceeds the maximum number of words limit. While processing examples, we could set a maximum sequence length limit where longer sequences are chunked, also we could drop the last chunk if we want. Additionally, I used the `words-segmentation` package to split raw text into units. We can also set the unit type (e.g,. words vs. chars).

## Checklist

- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the _default_ branch of the repository (`main` or `master`).
- [x] My commit messages follow the [contribution guidelines](../CONTRIBUTING.md).
- [x] My code follows the established code style of the repository.
- [x] I added or updated tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
      visible errors.